### PR TITLE
Generic std vector array update

### DIFF
--- a/ALU.vhd
+++ b/ALU.vhd
@@ -61,7 +61,7 @@ architecture ALUArch of ALU_DATAPATH is
 	end component;
 
 
-	use work.vector_array_d4w2.all;
+	use work.mux_array_pkg.all;
 	component Mux is 
 
 		generic(datalength : integer;
@@ -70,7 +70,7 @@ architecture ALUArch of ALU_DATAPATH is
 
 		port(
 
-			data_in : in array_of_vect; --this is not defined(?)
+			data_in : in mux_array; --this is not defined(?)
 			selector : in std_logic_vector((selectorlength - 1) downto 0);
 
 			data_out : out std_logic_vector((datalength - 1) downto 0)

--- a/Branch_Logic_Unit.vhd
+++ b/Branch_Logic_Unit.vhd
@@ -48,7 +48,7 @@ end Branch_Logic_Unit;
 
 architecture Behavioral of Branch_Logic_Unit is
 
-use work.vector_array_d1w8.all;
+use work.mux_array_pkg.all;
 component mux is
 
     generic(datalength : integer;
@@ -56,7 +56,7 @@ component mux is
             
     port(
         
-        data_in : in array_of_vect;
+        data_in : in mux_array;
         selector : in std_logic_vector((selectorlength - 1) downto 0);
         
         data_out : out std_logic_vector((datalength - 1) downto 0)

--- a/Control_Unit.vhd
+++ b/Control_Unit.vhd
@@ -126,7 +126,7 @@ end entity;
 architecture ControlUnitArch of ControlUnit is
 
 
-use work.vector_array.all;
+use work.mux_array_pkg.all;
 component mux is 
 
     generic(datalength : integer;
@@ -134,7 +134,7 @@ component mux is
     
     port(
         
-            data_in : in array_of_vect; --this is not defined(?)
+            data_in : in mux_array; --this is not defined(?)
             selector : in std_logic_vector((selectorlength - 1) downto 0);
             
             data_out : out std_logic_vector((datalength - 1) downto 0)
@@ -145,7 +145,7 @@ component mux is
 end component mux;
 
 
-use work.vector_array.all;
+use work.mux_array_pkg.all;
 component demux is
     
     generic(datalength : integer;
@@ -155,7 +155,7 @@ component demux is
         data_in : in std_logic_vector((datalength - 1) downto 0);
         selector : in std_logic_vector((selectorlength - 1) downto 0);
         
-        data_out : out array_of_vect
+        data_out : out mux_array
         
     );
     

--- a/Demux.vhd
+++ b/Demux.vhd
@@ -34,7 +34,7 @@ use IEEE.NUMERIC_STD.ALL;
 
 
 
-use work.vector_array.all;
+use work.mux_array_pkg.all;
 
 entity demux is
     
@@ -46,7 +46,7 @@ entity demux is
         data_in : in std_logic_vector((datalength - 1) downto 0);
         selector : in std_logic_vector((selectorlength - 1) downto 0);
         
-        data_out : out array_of_vect
+        data_out : out mux_array(2**selectorlength - 1 downto 0)(datalength - 1 downto 0)
         
     );
     

--- a/Functional_Unit.vhd
+++ b/Functional_Unit.vhd
@@ -53,7 +53,7 @@ end Functional_Unit;
 
 architecture Behavioral of Functional_Unit is
 
-use work.vector_array_d4w16.all;
+use work.mux_array_pkg.all;
 component mux is
 
     generic(datalength : integer;
@@ -61,7 +61,7 @@ component mux is
     
     port(
         
-        data_in : in array_of_vect; --this is not defined(?)
+        data_in : in mux_array; --this is not defined(?)
         selector : in std_logic_vector((selectorlength - 1) downto 0);
         
         data_out : out std_logic_vector((datalength - 1) downto 0)

--- a/Mux.vhd
+++ b/Mux.vhd
@@ -33,17 +33,18 @@ use IEEE.STD_LOGIC_1164.ALL;
 
 library IEEE;
 use IEEE.STD_LOGIC_1164.ALL;
-use work.vector_array.all;
 use ieee.numeric_std.all;
+use work.mux_array_pkg.all;
 
 entity mux is
 
     generic(datalength : integer;
             selectorlength : integer);
     
+    
     port(
         
-        data_in : in array_of_vect; --this is not defined(?)
+        data_in : in mux_array(2** selectorlength - 1 downto 0)(datalength - 1 downto 0); --this is not defined(?)
         selector : in std_logic_vector((selectorlength - 1) downto 0);
         
         data_out : out std_logic_vector((datalength - 1) downto 0)

--- a/Register_File.vhd
+++ b/Register_File.vhd
@@ -32,7 +32,13 @@ use IEEE.STD_LOGIC_1164.ALL;
 --use UNISIM.VComponents.all;
 
 entity Register_File is
-
+    
+    generic(
+            addrLength : integer;
+            datalength : integer
+            
+    );
+    
     port(
         
         Destination_Data : in std_logic_vector(3 downto 0);
@@ -69,14 +75,14 @@ architecture Behavioral of Register_File is
             );
     end component reg;
     
-    use work.vector_array.all;
+    use work.mux_array_pkg.all;
     component mux is 
     
         generic(datalength : integer;
                 selectorlength : integer);
         
         port(
-                data_in : in array_of_vect;
+                data_in : in mux_array;
                 selector : in std_logic_vector((selectorlength - 1) downto 0);
                 data_out : out std_logic_vector((datalength - 1) downto 0)              
         );
@@ -92,15 +98,15 @@ architecture Behavioral of Register_File is
         port(
             data_in : in std_logic_vector((datalength - 1) downto 0);
             selector : in std_logic_vector((selectorlength - 1 ) downto 0);
-            data_out : out array_of_vect
+            data_out : out mux_array
             );
        
     end component demux;
     
     --signals--
     
-    signal data_in_demux_to_regs : array_of_vect;
-    signal data_from_regs_to_mux : array_of_vect;
+    signal data_in_demux_to_regs : mux_array(2**addrLength - 1 downto 0)(datalength - 1 downto 0);
+    signal data_from_regs_to_mux : mux_array(2**addrLength - 1 downto 0)(datalength - 1 downto 0);
     signal enableSignals : std_logic_vector(7 downto 0);
 
     
@@ -110,7 +116,7 @@ begin
     --test_demux <= data_in_demux_to_regs(0);
 
     REG_GEN: for I in 0 to 7 generate
-        REGN: reg generic map(bitlength => 4) port map(
+        REGN: reg generic map(bitlength => datalength) port map(
             data_in => data_in_demux_to_regs(I),
             data_out => data_from_regs_to_mux(I),
             clk => clk_regfile,
@@ -120,8 +126,8 @@ begin
         );
        end generate;
    
-    DEMUX_DATA_GEN: demux generic map(datalength => 4,
-                              selectorlength => 3)
+    DEMUX_DATA_GEN: demux generic map(datalength => datalength,
+                              selectorlength => addrLength)
                   port map(
                     data_in => Destination_Data,
                     selector => Destination_Address,
@@ -139,7 +145,7 @@ begin
                   
                   
     DEMUX_ADDRESS_GEN: demux generic map(datalength => 1,
-                              selectorlength => 3)
+                              selectorlength => addrLength)
                   port map(
                     data_in(0) => read_write,
                     selector => Destination_Address,
@@ -154,8 +160,8 @@ begin
                   );
                   
                   
-    MUX_A: mux generic map(datalength => 4,
-                              selectorlength => 3)
+    MUX_A: mux generic map(datalength => datalength,
+                              selectorlength => addrLength)
                   port map(
                    data_in(0) => data_from_regs_to_mux(0),
                    data_in(1) => data_from_regs_to_mux(1),
@@ -174,8 +180,8 @@ begin
                   );
                   
                   
-     MUX_B: mux generic map(datalength => 4,
-                              selectorlength => 3)
+     MUX_B: mux generic map(datalength => dataLength,
+                              selectorlength => addrLength)
                   port map(
                   
                    data_in(0) => data_from_regs_to_mux(0),

--- a/packages.vhd
+++ b/packages.vhd
@@ -25,25 +25,32 @@ use IEEE.STD_LOGIC_1164.ALL;
 --i realize what is in this file is bad design (in my opinion)
 --but it is being done just to get used to using generic packages
 
-package array_of_vector_pkg is
+
+package mux_array_pkg is 
+
+    type mux_array is array(natural range <>) of std_logic_vector;
+
+end package mux_array_pkg;
+
+--package array_of_vector_pkg is
     
- generic (arraysize, bitlength : integer);
- type array_of_vect is array ((arraysize - 1) downto 0) of std_logic_vector((bitlength - 1) downto 0);
+-- generic (arraysize, bitlength : integer);
+-- type array_of_vect is array ((arraysize - 1) downto 0) of std_logic_vector((bitlength - 1) downto 0);
 
-end package;
+--end package;
 
-package vector_array is new work.array_of_vector_pkg
-    generic map(arraysize => 8, bitlength => 4);
+--package vector_array is new work.array_of_vector_pkg
+--    generic map(arraysize => 8, bitlength => 4);
 
---notation is vector_array with data size of 3 bits per vector, 8 vectors wide
-package vector_array_d1w8 is new work.array_of_vector_pkg
-    generic map(arraysize => 8, bitlength => 1);
+----notation is vector_array with data size of 3 bits per vector, 8 vectors wide
+--package vector_array_d1w8 is new work.array_of_vector_pkg
+--    generic map(arraysize => 8, bitlength => 1);
    
-package vector_array_d4w16 is new work.array_of_vector_pkg
-    generic map(arraysize => 16, bitlength => 4);
+--package vector_array_d4w16 is new work.array_of_vector_pkg
+--    generic map(arraysize => 16, bitlength => 4);
 
-package vector_array_d4w2 is new work.array_of_vector_pkg
-    generic map(arraysize => 2, bitlength => 4);
+--package vector_array_d4w2 is new work.array_of_vector_pkg
+--    generic map(arraysize => 2, bitlength => 4);
     
-package vector_array_d8w2 is new work.array_of_vector_pkg
-    generic map(arraysize => 2, bitlength => 8);
+--package vector_array_d8w2 is new work.array_of_vector_pkg
+--    generic map(arraysize => 2, bitlength => 8);

--- a/testbench/regfile_tb.vhd
+++ b/testbench/regfile_tb.vhd
@@ -30,7 +30,12 @@ architecture tb of regfiletb is
 
 
 component Register_File is
-
+    
+    generic(
+        datalength : integer;
+        addrLength : integer
+    );
+    
     port(
         
         Destination_Data : in std_logic_vector(3 downto 0);
@@ -69,7 +74,13 @@ begin
 
 
 
-	REGF_TB : register_file port map(
+	REGF_TB : register_file generic map(
+	                           datalength => 4,
+	                           addrLength => 3
+	
+	                       )
+	
+	                       port map(
 	
 							destination_data => destData,
 							destination_address => destAddr,


### PR DESCRIPTION
Created the mux_array_pkg in packages.vhd allowing for mux / demux inputs / outputs of definable data-lengths and selector-lengths, replacing the old vector_array packages. 

Also, Regfile and its associated testbench were updated to allow for generic datalengths and address-bit lengths.

Solves issue #18 