### PR TITLE
Modified ALU entity and Control Unit

### DIFF
--- a/MicroProcesserCirc2.circ
+++ b/MicroProcesserCirc2.circ
@@ -1,0 +1,1368 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project source="2.7.1" version="1.0">
+This file is intended to be loaded by Logisim (http://www.cburch.com/logisim/).
+<lib desc="#Wiring" name="0">
+    <tool name="Constant">
+      <a name="facing" val="south"/>
+    </tool>
+  </lib>
+  <lib desc="#Gates" name="1"/>
+  <lib desc="#Plexers" name="2"/>
+  <lib desc="#Arithmetic" name="3"/>
+  <lib desc="#Memory" name="4">
+    <tool name="ROM">
+      <a name="contents">addr/data: 8 8
+0
+</a>
+    </tool>
+  </lib>
+  <lib desc="#I/O" name="5"/>
+  <lib desc="#Base" name="6">
+    <tool name="Text Tool">
+      <a name="text" val=""/>
+      <a name="font" val="SansSerif plain 12"/>
+      <a name="halign" val="center"/>
+      <a name="valign" val="base"/>
+    </tool>
+  </lib>
+  <main name="ALU"/>
+  <options>
+    <a name="gateUndefined" val="ignore"/>
+    <a name="simlimit" val="1000"/>
+    <a name="simrand" val="0"/>
+  </options>
+  <mappings>
+    <tool lib="6" map="Button2" name="Menu Tool"/>
+    <tool lib="6" map="Button3" name="Menu Tool"/>
+    <tool lib="6" map="Ctrl Button1" name="Menu Tool"/>
+  </mappings>
+  <toolbar>
+    <tool lib="6" name="Poke Tool"/>
+    <tool lib="6" name="Edit Tool"/>
+    <tool lib="6" name="Text Tool">
+      <a name="text" val=""/>
+      <a name="font" val="SansSerif plain 12"/>
+      <a name="halign" val="center"/>
+      <a name="valign" val="base"/>
+    </tool>
+    <sep/>
+    <tool lib="0" name="Pin">
+      <a name="tristate" val="false"/>
+    </tool>
+    <tool lib="0" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="labelloc" val="east"/>
+    </tool>
+    <tool lib="1" name="NOT Gate"/>
+    <tool lib="1" name="AND Gate"/>
+    <tool lib="1" name="OR Gate"/>
+  </toolbar>
+  <circuit name="RF">
+    <a name="circuit" val="RF"/>
+    <a name="clabel" val="RF"/>
+    <a name="clabelup" val="west"/>
+    <a name="clabelfont" val="SansSerif plain 12"/>
+    <wire from="(530,450)" to="(530,460)"/>
+    <wire from="(650,130)" to="(650,140)"/>
+    <wire from="(670,510)" to="(720,510)"/>
+    <wire from="(760,520)" to="(810,520)"/>
+    <wire from="(410,270)" to="(530,270)"/>
+    <wire from="(680,170)" to="(720,170)"/>
+    <wire from="(490,330)" to="(490,350)"/>
+    <wire from="(250,170)" to="(490,170)"/>
+    <wire from="(240,150)" to="(240,230)"/>
+    <wire from="(330,280)" to="(330,360)"/>
+    <wire from="(420,180)" to="(660,180)"/>
+    <wire from="(170,90)" to="(170,110)"/>
+    <wire from="(470,190)" to="(470,220)"/>
+    <wire from="(540,130)" to="(650,130)"/>
+    <wire from="(250,60)" to="(290,60)"/>
+    <wire from="(640,80)" to="(640,120)"/>
+    <wire from="(250,70)" to="(280,70)"/>
+    <wire from="(350,20)" to="(350,130)"/>
+    <wire from="(710,200)" to="(710,430)"/>
+    <wire from="(370,450)" to="(370,490)"/>
+    <wire from="(100,90)" to="(120,90)"/>
+    <wire from="(380,340)" to="(380,380)"/>
+    <wire from="(420,180)" to="(420,220)"/>
+    <wire from="(370,490)" to="(520,490)"/>
+    <wire from="(520,240)" to="(520,280)"/>
+    <wire from="(250,80)" to="(270,80)"/>
+    <wire from="(300,40)" to="(300,220)"/>
+    <wire from="(230,250)" to="(500,250)"/>
+    <wire from="(430,370)" to="(700,370)"/>
+    <wire from="(480,80)" to="(480,130)"/>
+    <wire from="(250,90)" to="(260,90)"/>
+    <wire from="(410,230)" to="(490,230)"/>
+    <wire from="(420,260)" to="(420,320)"/>
+    <wire from="(710,550)" to="(720,550)"/>
+    <wire from="(330,160)" to="(330,280)"/>
+    <wire from="(290,320)" to="(360,320)"/>
+    <wire from="(670,120)" to="(670,130)"/>
+    <wire from="(300,220)" to="(360,220)"/>
+    <wire from="(290,60)" to="(290,320)"/>
+    <wire from="(670,160)" to="(720,160)"/>
+    <wire from="(330,360)" to="(330,490)"/>
+    <wire from="(340,50)" to="(340,190)"/>
+    <wire from="(660,180)" to="(660,500)"/>
+    <wire from="(240,230)" to="(360,230)"/>
+    <wire from="(190,200)" to="(190,470)"/>
+    <wire from="(660,500)" to="(720,500)"/>
+    <wire from="(120,90)" to="(170,90)"/>
+    <wire from="(370,340)" to="(370,360)"/>
+    <wire from="(500,230)" to="(500,250)"/>
+    <wire from="(660,150)" to="(660,180)"/>
+    <wire from="(330,490)" to="(330,570)"/>
+    <wire from="(490,140)" to="(490,170)"/>
+    <wire from="(480,290)" to="(480,320)"/>
+    <wire from="(160,210)" to="(160,240)"/>
+    <wire from="(250,140)" to="(250,170)"/>
+    <wire from="(260,520)" to="(490,520)"/>
+    <wire from="(250,20)" to="(350,20)"/>
+    <wire from="(490,190)" to="(530,190)"/>
+    <wire from="(390,130)" to="(480,130)"/>
+    <wire from="(700,370)" to="(700,540)"/>
+    <wire from="(520,450)" to="(520,490)"/>
+    <wire from="(530,340)" to="(530,380)"/>
+    <wire from="(640,120)" to="(640,480)"/>
+    <wire from="(220,450)" to="(220,610)"/>
+    <wire from="(220,170)" to="(220,330)"/>
+    <wire from="(200,440)" to="(360,440)"/>
+    <wire from="(390,220)" to="(420,220)"/>
+    <wire from="(700,540)" to="(720,540)"/>
+    <wire from="(480,80)" to="(640,80)"/>
+    <wire from="(490,330)" to="(510,330)"/>
+    <wire from="(210,350)" to="(490,350)"/>
+    <wire from="(260,90)" to="(260,520)"/>
+    <wire from="(650,490)" to="(720,490)"/>
+    <wire from="(500,230)" to="(510,230)"/>
+    <wire from="(710,430)" to="(710,550)"/>
+    <wire from="(90,270)" to="(230,270)"/>
+    <wire from="(670,160)" to="(670,220)"/>
+    <wire from="(180,140)" to="(250,140)"/>
+    <wire from="(420,260)" to="(680,260)"/>
+    <wire from="(230,270)" to="(230,390)"/>
+    <wire from="(710,200)" to="(720,200)"/>
+    <wire from="(280,290)" to="(480,290)"/>
+    <wire from="(180,130)" to="(310,130)"/>
+    <wire from="(740,210)" to="(740,390)"/>
+    <wire from="(670,130)" to="(720,130)"/>
+    <wire from="(80,170)" to="(140,170)"/>
+    <wire from="(180,150)" to="(240,150)"/>
+    <wire from="(190,470)" to="(500,470)"/>
+    <wire from="(180,160)" to="(230,160)"/>
+    <wire from="(660,150)" to="(720,150)"/>
+    <wire from="(680,260)" to="(680,520)"/>
+    <wire from="(310,130)" to="(310,140)"/>
+    <wire from="(370,150)" to="(370,160)"/>
+    <wire from="(760,170)" to="(820,170)"/>
+    <wire from="(680,170)" to="(680,260)"/>
+    <wire from="(410,380)" to="(410,460)"/>
+    <wire from="(650,140)" to="(650,490)"/>
+    <wire from="(690,320)" to="(690,530)"/>
+    <wire from="(280,70)" to="(280,290)"/>
+    <wire from="(500,440)" to="(500,470)"/>
+    <wire from="(230,160)" to="(230,250)"/>
+    <wire from="(270,80)" to="(270,430)"/>
+    <wire from="(180,170)" to="(220,170)"/>
+    <wire from="(380,240)" to="(380,270)"/>
+    <wire from="(520,340)" to="(520,360)"/>
+    <wire from="(330,280)" to="(370,280)"/>
+    <wire from="(330,160)" to="(370,160)"/>
+    <wire from="(330,360)" to="(370,360)"/>
+    <wire from="(470,220)" to="(510,220)"/>
+    <wire from="(180,60)" to="(210,60)"/>
+    <wire from="(180,180)" to="(210,180)"/>
+    <wire from="(530,150)" to="(530,190)"/>
+    <wire from="(540,320)" to="(690,320)"/>
+    <wire from="(500,30)" to="(500,130)"/>
+    <wire from="(480,320)" to="(510,320)"/>
+    <wire from="(700,190)" to="(720,190)"/>
+    <wire from="(380,460)" to="(410,460)"/>
+    <wire from="(380,380)" to="(410,380)"/>
+    <wire from="(690,530)" to="(720,530)"/>
+    <wire from="(640,120)" to="(670,120)"/>
+    <wire from="(490,140)" to="(510,140)"/>
+    <wire from="(180,190)" to="(200,190)"/>
+    <wire from="(410,230)" to="(410,270)"/>
+    <wire from="(490,190)" to="(490,230)"/>
+    <wire from="(500,440)" to="(510,440)"/>
+    <wire from="(650,140)" to="(720,140)"/>
+    <wire from="(350,130)" to="(360,130)"/>
+    <wire from="(180,200)" to="(190,200)"/>
+    <wire from="(540,220)" to="(670,220)"/>
+    <wire from="(220,330)" to="(360,330)"/>
+    <wire from="(640,480)" to="(720,480)"/>
+    <wire from="(740,560)" to="(740,610)"/>
+    <wire from="(200,190)" to="(200,440)"/>
+    <wire from="(430,370)" to="(430,430)"/>
+    <wire from="(220,610)" to="(740,610)"/>
+    <wire from="(90,450)" to="(220,450)"/>
+    <wire from="(230,390)" to="(740,390)"/>
+    <wire from="(250,30)" to="(500,30)"/>
+    <wire from="(690,180)" to="(690,320)"/>
+    <wire from="(170,110)" to="(230,110)"/>
+    <wire from="(180,50)" to="(180,60)"/>
+    <wire from="(230,100)" to="(230,110)"/>
+    <wire from="(310,140)" to="(360,140)"/>
+    <wire from="(520,150)" to="(520,160)"/>
+    <wire from="(250,40)" to="(300,40)"/>
+    <wire from="(410,380)" to="(530,380)"/>
+    <wire from="(410,460)" to="(530,460)"/>
+    <wire from="(380,450)" to="(380,460)"/>
+    <wire from="(680,520)" to="(720,520)"/>
+    <wire from="(80,380)" to="(380,380)"/>
+    <wire from="(410,150)" to="(410,230)"/>
+    <wire from="(530,240)" to="(530,270)"/>
+    <wire from="(120,90)" to="(120,240)"/>
+    <wire from="(120,240)" to="(160,240)"/>
+    <wire from="(330,490)" to="(370,490)"/>
+    <wire from="(490,430)" to="(490,520)"/>
+    <wire from="(390,430)" to="(430,430)"/>
+    <wire from="(540,430)" to="(710,430)"/>
+    <wire from="(270,430)" to="(360,430)"/>
+    <wire from="(390,320)" to="(420,320)"/>
+    <wire from="(250,50)" to="(340,50)"/>
+    <wire from="(380,150)" to="(410,150)"/>
+    <wire from="(380,270)" to="(410,270)"/>
+    <wire from="(690,180)" to="(720,180)"/>
+    <wire from="(670,220)" to="(670,510)"/>
+    <wire from="(410,270)" to="(410,380)"/>
+    <wire from="(210,180)" to="(210,350)"/>
+    <wire from="(490,430)" to="(510,430)"/>
+    <wire from="(370,240)" to="(370,280)"/>
+    <wire from="(370,280)" to="(520,280)"/>
+    <wire from="(370,160)" to="(520,160)"/>
+    <wire from="(370,360)" to="(520,360)"/>
+    <wire from="(500,130)" to="(510,130)"/>
+    <wire from="(110,50)" to="(180,50)"/>
+    <wire from="(340,190)" to="(470,190)"/>
+    <wire from="(70,570)" to="(330,570)"/>
+    <wire from="(700,190)" to="(700,370)"/>
+    <comp lib="4" loc="(540,220)" name="Register">
+      <a name="width" val="4"/>
+    </comp>
+    <comp lib="0" loc="(70,570)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="CLK"/>
+    </comp>
+    <comp lib="0" loc="(110,50)" name="Pin">
+      <a name="width" val="4"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="DI"/>
+    </comp>
+    <comp lib="2" loc="(760,170)" name="Multiplexer">
+      <a name="select" val="3"/>
+      <a name="width" val="4"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="2" loc="(210,60)" name="Demultiplexer">
+      <a name="select" val="3"/>
+      <a name="width" val="4"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(90,450)" name="Pin">
+      <a name="width" val="3"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="BA"/>
+    </comp>
+    <comp lib="4" loc="(540,430)" name="Register">
+      <a name="width" val="4"/>
+    </comp>
+    <comp lib="4" loc="(390,130)" name="Register">
+      <a name="width" val="4"/>
+    </comp>
+    <comp lib="2" loc="(140,170)" name="Demultiplexer">
+      <a name="select" val="3"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(90,270)" name="Pin">
+      <a name="width" val="3"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="AA"/>
+    </comp>
+    <comp lib="2" loc="(760,520)" name="Multiplexer">
+      <a name="select" val="3"/>
+      <a name="width" val="4"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="4" loc="(390,430)" name="Register">
+      <a name="width" val="4"/>
+    </comp>
+    <comp lib="4" loc="(540,320)" name="Register">
+      <a name="width" val="4"/>
+    </comp>
+    <comp lib="4" loc="(390,220)" name="Register">
+      <a name="width" val="4"/>
+    </comp>
+    <comp lib="0" loc="(820,170)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="4"/>
+      <a name="label" val="AO"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="6" loc="(278,680)" name="Text">
+      <a name="text" val="Register File"/>
+    </comp>
+    <comp lib="0" loc="(100,90)" name="Pin">
+      <a name="width" val="3"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="DA"/>
+    </comp>
+    <comp lib="0" loc="(80,380)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="RESET"/>
+    </comp>
+    <comp lib="0" loc="(810,520)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="4"/>
+      <a name="label" val="BO"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(540,130)" name="Register">
+      <a name="width" val="4"/>
+    </comp>
+    <comp lib="0" loc="(80,170)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="WR"/>
+    </comp>
+    <comp lib="4" loc="(390,320)" name="Register">
+      <a name="width" val="4"/>
+    </comp>
+  </circuit>
+  <circuit name="CAR">
+    <a name="circuit" val="CAR"/>
+    <a name="clabel" val="CAR"/>
+    <a name="clabelup" val="east"/>
+    <a name="clabelfont" val="SansSerif plain 12"/>
+    <wire from="(380,320)" to="(440,320)"/>
+    <wire from="(510,310)" to="(570,310)"/>
+    <wire from="(480,390)" to="(540,390)"/>
+    <wire from="(410,310)" to="(440,310)"/>
+    <wire from="(510,370)" to="(540,370)"/>
+    <wire from="(260,350)" to="(450,350)"/>
+    <wire from="(420,300)" to="(440,300)"/>
+    <wire from="(410,300)" to="(410,310)"/>
+    <wire from="(420,260)" to="(420,300)"/>
+    <wire from="(270,300)" to="(410,300)"/>
+    <wire from="(450,330)" to="(450,350)"/>
+    <wire from="(580,380)" to="(650,380)"/>
+    <wire from="(340,320)" to="(350,320)"/>
+    <wire from="(250,350)" to="(260,350)"/>
+    <wire from="(340,260)" to="(420,260)"/>
+    <wire from="(340,260)" to="(340,320)"/>
+    <wire from="(460,330)" to="(460,390)"/>
+    <wire from="(510,310)" to="(510,370)"/>
+    <wire from="(420,390)" to="(460,390)"/>
+    <wire from="(270,260)" to="(340,260)"/>
+    <wire from="(470,310)" to="(510,310)"/>
+    <comp lib="6" loc="(306,100)" name="Text">
+      <a name="text" val="Address Counter."/>
+    </comp>
+    <comp lib="3" loc="(580,380)" name="Comparator"/>
+    <comp lib="0" loc="(420,390)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="RESET"/>
+    </comp>
+    <comp lib="4" loc="(470,310)" name="Counter">
+      <a name="label" val="NEXT_ADR"/>
+    </comp>
+    <comp lib="0" loc="(260,350)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="CLK"/>
+    </comp>
+    <comp lib="6" loc="(278,163)" name="Text">
+      <a name="text" val="When Mode = 0, counter increments the loaded value"/>
+    </comp>
+    <comp lib="1" loc="(380,320)" name="NOT Gate"/>
+    <comp lib="0" loc="(270,260)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="MODE"/>
+    </comp>
+    <comp lib="6" loc="(145,333)" name="Text">
+      <a name="text" val="J_ADDR = jump address"/>
+    </comp>
+    <comp lib="0" loc="(270,300)" name="Pin">
+      <a name="width" val="8"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="J_ADDR"/>
+    </comp>
+    <comp lib="6" loc="(347,203)" name="Text">
+      <a name="text" val="Ready indicates that the processor is ready to execute the next input instruction"/>
+    </comp>
+    <comp lib="6" loc="(266,138)" name="Text">
+      <a name="text" val="When Mode = 1, loads J_ADDR into the Counter"/>
+    </comp>
+    <comp lib="0" loc="(650,380)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="READY"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="6" loc="(331,218)" name="Text">
+      <a name="text" val="Therefore, it is only ready when address = 0x00, the start address in ROM"/>
+    </comp>
+    <comp lib="0" loc="(480,390)" name="Ground">
+      <a name="width" val="8"/>
+    </comp>
+    <comp lib="0" loc="(570,310)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="8"/>
+      <a name="label" val="NEXT_ADDR"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+  </circuit>
+  <circuit name="BRA_LOG">
+    <a name="circuit" val="BRA_LOG"/>
+    <a name="clabel" val="BL"/>
+    <a name="clabelup" val="south"/>
+    <a name="clabelfont" val="SansSerif plain 12"/>
+    <wire from="(670,240)" to="(720,240)"/>
+    <wire from="(270,210)" to="(270,340)"/>
+    <wire from="(580,230)" to="(630,230)"/>
+    <wire from="(290,370)" to="(340,370)"/>
+    <wire from="(270,360)" to="(320,360)"/>
+    <wire from="(240,320)" to="(290,320)"/>
+    <wire from="(320,300)" to="(440,300)"/>
+    <wire from="(280,330)" to="(280,350)"/>
+    <wire from="(270,340)" to="(270,360)"/>
+    <wire from="(350,370)" to="(350,390)"/>
+    <wire from="(590,250)" to="(630,250)"/>
+    <wire from="(290,240)" to="(290,320)"/>
+    <wire from="(490,420)" to="(600,420)"/>
+    <wire from="(620,270)" to="(620,350)"/>
+    <wire from="(340,330)" to="(440,330)"/>
+    <wire from="(290,370)" to="(290,400)"/>
+    <wire from="(270,360)" to="(270,390)"/>
+    <wire from="(240,330)" to="(280,330)"/>
+    <wire from="(490,350)" to="(590,350)"/>
+    <wire from="(270,210)" to="(630,210)"/>
+    <wire from="(310,260)" to="(310,350)"/>
+    <wire from="(280,350)" to="(280,440)"/>
+    <wire from="(240,340)" to="(270,340)"/>
+    <wire from="(490,280)" to="(580,280)"/>
+    <wire from="(350,370)" to="(440,370)"/>
+    <wire from="(280,440)" to="(440,440)"/>
+    <wire from="(280,350)" to="(310,350)"/>
+    <wire from="(280,220)" to="(630,220)"/>
+    <wire from="(290,240)" to="(630,240)"/>
+    <wire from="(600,260)" to="(600,420)"/>
+    <wire from="(280,220)" to="(280,330)"/>
+    <wire from="(70,350)" to="(220,350)"/>
+    <wire from="(600,260)" to="(630,260)"/>
+    <wire from="(590,250)" to="(590,350)"/>
+    <wire from="(340,330)" to="(340,370)"/>
+    <wire from="(290,400)" to="(440,400)"/>
+    <wire from="(270,390)" to="(350,390)"/>
+    <wire from="(650,140)" to="(650,200)"/>
+    <wire from="(290,320)" to="(290,370)"/>
+    <wire from="(320,300)" to="(320,360)"/>
+    <wire from="(370,200)" to="(630,200)"/>
+    <wire from="(580,230)" to="(580,280)"/>
+    <wire from="(310,260)" to="(440,260)"/>
+    <wire from="(70,140)" to="(650,140)"/>
+    <wire from="(620,270)" to="(630,270)"/>
+    <wire from="(620,350)" to="(630,350)"/>
+    <comp lib="2" loc="(670,240)" name="Multiplexer">
+      <a name="selloc" val="tr"/>
+      <a name="select" val="3"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(370,200)" name="Constant">
+      <a name="facing" val="south"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="1" loc="(490,280)" name="OR Gate">
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(70,140)" name="Pin">
+      <a name="width" val="3"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="COND"/>
+    </comp>
+    <comp lib="0" loc="(630,350)" name="Constant">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="0" loc="(720,240)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="BRA"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="1" loc="(490,420)" name="OR Gate">
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(490,350)" name="OR Gate">
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="0" loc="(70,350)" name="Pin">
+      <a name="width" val="3"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="PZN"/>
+    </comp>
+    <comp lib="0" loc="(220,350)" name="Splitter">
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
+      <a name="bit0" val="2"/>
+      <a name="bit2" val="0"/>
+    </comp>
+  </circuit>
+  <circuit name="FU">
+    <a name="circuit" val="FU"/>
+    <a name="clabel" val="FU"/>
+    <a name="clabelup" val="west"/>
+    <a name="clabelfont" val="SansSerif plain 12"/>
+    <wire from="(710,370)" to="(710,380)"/>
+    <wire from="(630,300)" to="(630,630)"/>
+    <wire from="(90,450)" to="(90,580)"/>
+    <wire from="(90,580)" to="(150,580)"/>
+    <wire from="(760,380)" to="(810,380)"/>
+    <wire from="(180,570)" to="(620,570)"/>
+    <wire from="(630,300)" to="(690,300)"/>
+    <wire from="(290,710)" to="(290,720)"/>
+    <wire from="(90,450)" to="(140,450)"/>
+    <wire from="(90,350)" to="(140,350)"/>
+    <wire from="(90,630)" to="(140,630)"/>
+    <wire from="(100,560)" to="(150,560)"/>
+    <wire from="(760,290)" to="(820,290)"/>
+    <wire from="(760,290)" to="(760,380)"/>
+    <wire from="(600,270)" to="(600,490)"/>
+    <wire from="(900,370)" to="(940,370)"/>
+    <wire from="(800,400)" to="(800,420)"/>
+    <wire from="(100,430)" to="(140,430)"/>
+    <wire from="(100,330)" to="(140,330)"/>
+    <wire from="(580,250)" to="(690,250)"/>
+    <wire from="(90,260)" to="(90,350)"/>
+    <wire from="(100,590)" to="(100,680)"/>
+    <wire from="(180,490)" to="(600,490)"/>
+    <wire from="(200,660)" to="(300,660)"/>
+    <wire from="(100,560)" to="(100,590)"/>
+    <wire from="(100,590)" to="(260,590)"/>
+    <wire from="(60,260)" to="(90,260)"/>
+    <wire from="(180,440)" to="(590,440)"/>
+    <wire from="(260,640)" to="(290,640)"/>
+    <wire from="(730,290)" to="(760,290)"/>
+    <wire from="(90,260)" to="(560,260)"/>
+    <wire from="(200,620)" to="(200,660)"/>
+    <wire from="(570,240)" to="(570,340)"/>
+    <wire from="(120,610)" to="(140,610)"/>
+    <wire from="(180,690)" to="(200,690)"/>
+    <wire from="(850,390)" to="(880,390)"/>
+    <wire from="(600,270)" to="(690,270)"/>
+    <wire from="(100,380)" to="(100,430)"/>
+    <wire from="(620,290)" to="(690,290)"/>
+    <wire from="(90,350)" to="(90,400)"/>
+    <wire from="(180,390)" to="(580,390)"/>
+    <wire from="(100,480)" to="(100,530)"/>
+    <wire from="(610,280)" to="(610,530)"/>
+    <wire from="(640,310)" to="(640,690)"/>
+    <wire from="(180,340)" to="(570,340)"/>
+    <wire from="(800,400)" to="(810,400)"/>
+    <wire from="(730,470)" to="(740,470)"/>
+    <wire from="(570,240)" to="(690,240)"/>
+    <wire from="(580,250)" to="(580,390)"/>
+    <wire from="(90,630)" to="(90,700)"/>
+    <wire from="(640,310)" to="(690,310)"/>
+    <wire from="(230,680)" to="(280,680)"/>
+    <wire from="(230,700)" to="(280,700)"/>
+    <wire from="(300,650)" to="(300,660)"/>
+    <wire from="(320,630)" to="(630,630)"/>
+    <wire from="(90,700)" to="(140,700)"/>
+    <wire from="(90,400)" to="(140,400)"/>
+    <wire from="(100,530)" to="(150,530)"/>
+    <wire from="(740,380)" to="(740,470)"/>
+    <wire from="(180,530)" to="(610,530)"/>
+    <wire from="(620,290)" to="(620,570)"/>
+    <wire from="(590,260)" to="(690,260)"/>
+    <wire from="(560,230)" to="(560,260)"/>
+    <wire from="(100,480)" to="(140,480)"/>
+    <wire from="(100,680)" to="(140,680)"/>
+    <wire from="(100,380)" to="(140,380)"/>
+    <wire from="(200,690)" to="(200,720)"/>
+    <wire from="(100,530)" to="(100,560)"/>
+    <wire from="(200,720)" to="(290,720)"/>
+    <wire from="(710,380)" to="(740,380)"/>
+    <wire from="(770,420)" to="(800,420)"/>
+    <wire from="(120,500)" to="(140,500)"/>
+    <wire from="(180,620)" to="(200,620)"/>
+    <wire from="(100,220)" to="(100,330)"/>
+    <wire from="(850,400)" to="(880,400)"/>
+    <wire from="(850,380)" to="(880,380)"/>
+    <wire from="(100,430)" to="(100,480)"/>
+    <wire from="(90,580)" to="(90,630)"/>
+    <wire from="(310,690)" to="(640,690)"/>
+    <wire from="(100,220)" to="(690,220)"/>
+    <wire from="(100,330)" to="(100,380)"/>
+    <wire from="(90,400)" to="(90,450)"/>
+    <wire from="(260,590)" to="(260,640)"/>
+    <wire from="(560,230)" to="(690,230)"/>
+    <wire from="(90,220)" to="(100,220)"/>
+    <wire from="(610,280)" to="(690,280)"/>
+    <wire from="(590,260)" to="(590,440)"/>
+    <comp lib="3" loc="(180,690)" name="Comparator">
+      <a name="width" val="4"/>
+    </comp>
+    <comp lib="3" loc="(180,390)" name="Subtractor">
+      <a name="width" val="4"/>
+    </comp>
+    <comp lib="3" loc="(850,390)" name="Comparator">
+      <a name="width" val="4"/>
+    </comp>
+    <comp lib="0" loc="(820,290)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="4"/>
+      <a name="label" val="OUT"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="3" loc="(180,340)" name="Adder">
+      <a name="width" val="4"/>
+    </comp>
+    <comp lib="2" loc="(310,690)" name="Multiplexer">
+      <a name="width" val="4"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(230,680)" name="Constant">
+      <a name="width" val="4"/>
+    </comp>
+    <comp lib="3" loc="(180,440)" name="Multiplier">
+      <a name="width" val="4"/>
+    </comp>
+    <comp lib="2" loc="(320,630)" name="Multiplexer">
+      <a name="width" val="4"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(60,260)" name="Pin">
+      <a name="width" val="4"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="C"/>
+    </comp>
+    <comp lib="0" loc="(770,420)" name="Constant">
+      <a name="width" val="4"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="2" loc="(730,290)" name="Multiplexer">
+      <a name="select" val="4"/>
+      <a name="width" val="4"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(900,370)" name="Splitter">
+      <a name="facing" val="west"/>
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="3"/>
+    </comp>
+    <comp lib="0" loc="(90,220)" name="Pin">
+      <a name="width" val="4"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="ValM[A]"/>
+    </comp>
+    <comp lib="0" loc="(230,700)" name="Constant">
+      <a name="width" val="4"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="0" loc="(120,500)" name="Constant">
+      <a name="width" val="2"/>
+    </comp>
+    <comp lib="3" loc="(180,620)" name="Comparator">
+      <a name="width" val="4"/>
+    </comp>
+    <comp lib="0" loc="(120,610)" name="Constant">
+      <a name="width" val="4"/>
+      <a name="value" val="0x0"/>
+    </comp>
+    <comp lib="3" loc="(180,490)" name="Shifter">
+      <a name="width" val="4"/>
+      <a name="shift" val="lr"/>
+    </comp>
+    <comp lib="0" loc="(940,370)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="3"/>
+      <a name="label" val="PZN"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="1" loc="(180,570)" name="AND Gate">
+      <a name="width" val="4"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="1" loc="(180,530)" name="NOT Gate">
+      <a name="width" val="4"/>
+    </comp>
+    <comp lib="0" loc="(730,470)" name="Pin">
+      <a name="width" val="4"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="OPCODE"/>
+    </comp>
+  </circuit>
+  <circuit name="CU">
+    <a name="circuit" val="CU"/>
+    <a name="clabel" val="CU"/>
+    <a name="clabelup" val="east"/>
+    <a name="clabelfont" val="SansSerif plain 12"/>
+    <wire from="(320,590)" to="(380,590)"/>
+    <wire from="(820,460)" to="(870,460)"/>
+    <wire from="(540,60)" to="(540,70)"/>
+    <wire from="(360,390)" to="(360,460)"/>
+    <wire from="(670,590)" to="(720,590)"/>
+    <wire from="(610,650)" to="(660,650)"/>
+    <wire from="(850,570)" to="(850,580)"/>
+    <wire from="(600,120)" to="(650,120)"/>
+    <wire from="(600,220)" to="(600,350)"/>
+    <wire from="(240,280)" to="(290,280)"/>
+    <wire from="(260,600)" to="(260,750)"/>
+    <wire from="(540,210)" to="(540,300)"/>
+    <wire from="(750,640)" to="(790,640)"/>
+    <wire from="(660,620)" to="(660,650)"/>
+    <wire from="(650,170)" to="(650,200)"/>
+    <wire from="(740,570)" to="(850,570)"/>
+    <wire from="(500,70)" to="(540,70)"/>
+    <wire from="(160,420)" to="(190,420)"/>
+    <wire from="(610,610)" to="(610,650)"/>
+    <wire from="(240,260)" to="(270,260)"/>
+    <wire from="(200,390)" to="(360,390)"/>
+    <wire from="(520,230)" to="(520,330)"/>
+    <wire from="(580,130)" to="(600,130)"/>
+    <wire from="(260,600)" to="(290,600)"/>
+    <wire from="(670,610)" to="(700,610)"/>
+    <wire from="(940,650)" to="(940,750)"/>
+    <wire from="(530,310)" to="(560,310)"/>
+    <wire from="(280,170)" to="(560,170)"/>
+    <wire from="(590,300)" to="(660,300)"/>
+    <wire from="(250,610)" to="(250,660)"/>
+    <wire from="(330,510)" to="(460,510)"/>
+    <wire from="(220,410)" to="(220,530)"/>
+    <wire from="(740,560)" to="(820,560)"/>
+    <wire from="(120,660)" to="(250,660)"/>
+    <wire from="(290,210)" to="(290,280)"/>
+    <wire from="(290,210)" to="(540,210)"/>
+    <wire from="(500,180)" to="(560,180)"/>
+    <wire from="(520,330)" to="(570,330)"/>
+    <wire from="(520,90)" to="(570,90)"/>
+    <wire from="(80,350)" to="(580,350)"/>
+    <wire from="(60,330)" to="(60,470)"/>
+    <wire from="(890,630)" to="(930,630)"/>
+    <wire from="(810,650)" to="(810,740)"/>
+    <wire from="(270,50)" to="(270,260)"/>
+    <wire from="(580,190)" to="(580,220)"/>
+    <wire from="(500,180)" to="(500,260)"/>
+    <wire from="(380,590)" to="(380,620)"/>
+    <wire from="(330,460)" to="(330,490)"/>
+    <wire from="(200,580)" to="(240,580)"/>
+    <wire from="(540,300)" to="(560,300)"/>
+    <wire from="(580,220)" to="(600,220)"/>
+    <wire from="(540,60)" to="(560,60)"/>
+    <wire from="(210,510)" to="(210,740)"/>
+    <wire from="(270,590)" to="(290,590)"/>
+    <wire from="(820,460)" to="(820,560)"/>
+    <wire from="(610,600)" to="(640,600)"/>
+    <wire from="(890,670)" to="(980,670)"/>
+    <wire from="(80,350)" to="(80,520)"/>
+    <wire from="(580,70)" to="(580,130)"/>
+    <wire from="(60,330)" to="(520,330)"/>
+    <wire from="(530,260)" to="(530,310)"/>
+    <wire from="(200,390)" to="(200,580)"/>
+    <wire from="(250,760)" to="(950,760)"/>
+    <wire from="(190,470)" to="(190,600)"/>
+    <wire from="(270,520)" to="(270,590)"/>
+    <wire from="(240,290)" to="(300,290)"/>
+    <wire from="(450,70)" to="(500,70)"/>
+    <wire from="(460,280)" to="(510,280)"/>
+    <wire from="(350,710)" to="(850,710)"/>
+    <wire from="(300,280)" to="(300,290)"/>
+    <wire from="(790,510)" to="(790,640)"/>
+    <wire from="(120,520)" to="(120,660)"/>
+    <wire from="(600,50)" to="(600,120)"/>
+    <wire from="(550,620)" to="(590,620)"/>
+    <wire from="(600,130)" to="(600,220)"/>
+    <wire from="(580,320)" to="(580,350)"/>
+    <wire from="(800,600)" to="(970,600)"/>
+    <wire from="(270,50)" to="(560,50)"/>
+    <wire from="(240,270)" to="(280,270)"/>
+    <wire from="(260,750)" to="(940,750)"/>
+    <wire from="(570,70)" to="(570,90)"/>
+    <wire from="(250,660)" to="(250,760)"/>
+    <wire from="(280,170)" to="(280,270)"/>
+    <wire from="(570,190)" to="(570,230)"/>
+    <wire from="(380,620)" to="(410,620)"/>
+    <wire from="(580,350)" to="(600,350)"/>
+    <wire from="(890,630)" to="(890,670)"/>
+    <wire from="(500,260)" to="(530,260)"/>
+    <wire from="(320,600)" to="(350,600)"/>
+    <wire from="(700,660)" to="(730,660)"/>
+    <wire from="(500,70)" to="(500,180)"/>
+    <wire from="(350,600)" to="(350,710)"/>
+    <wire from="(240,540)" to="(240,580)"/>
+    <wire from="(180,390)" to="(200,390)"/>
+    <wire from="(280,580)" to="(290,580)"/>
+    <wire from="(260,520)" to="(270,520)"/>
+    <wire from="(190,600)" to="(260,600)"/>
+    <wire from="(590,50)" to="(600,50)"/>
+    <wire from="(570,320)" to="(570,330)"/>
+    <wire from="(510,280)" to="(510,410)"/>
+    <wire from="(520,230)" to="(570,230)"/>
+    <wire from="(520,90)" to="(520,230)"/>
+    <wire from="(490,500)" to="(800,500)"/>
+    <wire from="(590,170)" to="(650,170)"/>
+    <wire from="(750,650)" to="(810,650)"/>
+    <wire from="(970,600)" to="(970,630)"/>
+    <wire from="(490,510)" to="(790,510)"/>
+    <wire from="(280,500)" to="(280,580)"/>
+    <wire from="(80,520)" to="(120,520)"/>
+    <wire from="(250,610)" to="(290,610)"/>
+    <wire from="(220,410)" to="(510,410)"/>
+    <wire from="(950,650)" to="(950,760)"/>
+    <wire from="(90,660)" to="(120,660)"/>
+    <wire from="(130,250)" to="(220,250)"/>
+    <wire from="(330,460)" to="(360,460)"/>
+    <wire from="(280,500)" to="(300,500)"/>
+    <wire from="(300,280)" to="(320,280)"/>
+    <wire from="(800,500)" to="(800,600)"/>
+    <wire from="(210,740)" to="(810,740)"/>
+    <wire from="(210,510)" to="(230,510)"/>
+    <wire from="(850,580)" to="(880,580)"/>
+    <wire from="(190,420)" to="(190,470)"/>
+    <wire from="(220,530)" to="(230,530)"/>
+    <wire from="(960,630)" to="(970,630)"/>
+    <wire from="(700,610)" to="(700,660)"/>
+    <wire from="(650,200)" to="(660,200)"/>
+    <wire from="(60,470)" to="(190,470)"/>
+    <comp lib="4" loc="(550,620)" name="ROM">
+      <a name="dataWidth" val="12"/>
+      <a name="contents">addr/data: 8 12
+16*0 221 400 14*0 221 423 103 220
+12*0 221 423 625 303 105 433 200
+9*0 221 423 625 303 105 443 200
+9*0 221 423 625 303 105 453 200
+9*0 221 423 303 63 200 11*0 221
+423 303 73 200 11*0 221 423 625
+303 105 483 200 9*0 625 105 420
+0 221 423 103 200 8*0 221 423
+625 103 105 4a3 200
+</a>
+    </comp>
+    <comp lib="0" loc="(180,390)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="START"/>
+    </comp>
+    <comp lib="0" loc="(90,660)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="RESET"/>
+    </comp>
+    <comp lib="4" loc="(590,50)" name="Register">
+      <a name="width" val="3"/>
+    </comp>
+    <comp lib="2" loc="(260,520)" name="Multiplexer">
+      <a name="width" val="8"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="4" loc="(590,300)" name="Register">
+      <a name="width" val="3"/>
+    </comp>
+    <comp lib="2" loc="(640,600)" name="Demultiplexer">
+      <a name="width" val="11"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(650,120)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="3"/>
+      <a name="label" val="D"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp loc="(320,590)" name="CAR"/>
+    <comp lib="0" loc="(450,70)" name="Constant">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="0" loc="(880,580)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="MW"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(870,460)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="7"/>
+      <a name="label" val="CW"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="4" loc="(590,170)" name="Register">
+      <a name="width" val="4"/>
+    </comp>
+    <comp lib="0" loc="(130,250)" name="Pin">
+      <a name="width" val="14"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="INST"/>
+    </comp>
+    <comp lib="0" loc="(220,250)" name="Splitter">
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="14"/>
+      <a name="appear" val="right"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="1"/>
+      <a name="bit4" val="1"/>
+      <a name="bit5" val="1"/>
+      <a name="bit6" val="1"/>
+      <a name="bit7" val="2"/>
+      <a name="bit8" val="2"/>
+      <a name="bit9" val="2"/>
+      <a name="bit10" val="3"/>
+      <a name="bit11" val="3"/>
+      <a name="bit12" val="3"/>
+      <a name="bit13" val="3"/>
+    </comp>
+    <comp lib="0" loc="(660,300)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="3"/>
+      <a name="label" val="A"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(850,710)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="label" val="READY"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp loc="(460,510)" name="BRA_LOG">
+      <a name="facing" val="west"/>
+    </comp>
+    <comp lib="0" loc="(720,590)" name="Splitter">
+      <a name="fanout" val="3"/>
+      <a name="incoming" val="11"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="1"/>
+      <a name="bit8" val="2"/>
+      <a name="bit9" val="2"/>
+      <a name="bit10" val="2"/>
+    </comp>
+    <comp lib="4" loc="(460,280)" name="ROM">
+      <a name="addrWidth" val="4"/>
+      <a name="contents">addr/data: 4 8
+0 10 20 30 40 50 60 70
+80 90 a0 b0 c0 d0 e0 f0
+</a>
+    </comp>
+    <comp lib="1" loc="(300,500)" name="OR Gate">
+      <a name="facing" val="west"/>
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="4" loc="(960,630)" name="Register">
+      <a name="width" val="3"/>
+    </comp>
+    <comp lib="0" loc="(590,620)" name="Splitter">
+      <a name="incoming" val="12"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="0"/>
+      <a name="bit4" val="0"/>
+      <a name="bit5" val="0"/>
+      <a name="bit6" val="0"/>
+      <a name="bit7" val="0"/>
+      <a name="bit8" val="0"/>
+      <a name="bit9" val="0"/>
+      <a name="bit10" val="0"/>
+      <a name="bit11" val="1"/>
+    </comp>
+    <comp lib="0" loc="(160,420)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="CLK"/>
+    </comp>
+    <comp lib="0" loc="(730,660)" name="Splitter">
+      <a name="incoming" val="11"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="1"/>
+      <a name="bit4" val="1"/>
+      <a name="bit5" val="1"/>
+      <a name="bit6" val="1"/>
+      <a name="bit7" val="1"/>
+      <a name="bit8" val="1"/>
+      <a name="bit9" val="1"/>
+      <a name="bit10" val="1"/>
+    </comp>
+    <comp lib="0" loc="(980,670)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="width" val="3"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="PZN"/>
+    </comp>
+    <comp lib="0" loc="(660,200)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="4"/>
+      <a name="label" val="C"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+  </circuit>
+  <circuit name="ALU">
+    <a name="circuit" val="ALU"/>
+    <a name="clabel" val="DU"/>
+    <a name="clabelup" val="east"/>
+    <a name="clabelfont" val="SansSerif plain 12"/>
+    <wire from="(420,410)" to="(670,410)"/>
+    <wire from="(460,370)" to="(460,440)"/>
+    <wire from="(390,90)" to="(440,90)"/>
+    <wire from="(20,320)" to="(20,590)"/>
+    <wire from="(470,20)" to="(470,220)"/>
+    <wire from="(450,70)" to="(450,220)"/>
+    <wire from="(20,590)" to="(130,590)"/>
+    <wire from="(400,510)" to="(400,720)"/>
+    <wire from="(280,110)" to="(280,190)"/>
+    <wire from="(170,20)" to="(470,20)"/>
+    <wire from="(130,590)" to="(130,610)"/>
+    <wire from="(140,580)" to="(140,600)"/>
+    <wire from="(450,250)" to="(450,280)"/>
+    <wire from="(420,280)" to="(420,310)"/>
+    <wire from="(410,430)" to="(410,460)"/>
+    <wire from="(430,490)" to="(430,520)"/>
+    <wire from="(400,280)" to="(400,310)"/>
+    <wire from="(330,130)" to="(430,130)"/>
+    <wire from="(140,580)" to="(500,580)"/>
+    <wire from="(190,670)" to="(190,700)"/>
+    <wire from="(310,280)" to="(400,280)"/>
+    <wire from="(110,650)" to="(140,650)"/>
+    <wire from="(420,280)" to="(450,280)"/>
+    <wire from="(390,210)" to="(420,210)"/>
+    <wire from="(460,370)" to="(670,370)"/>
+    <wire from="(400,510)" to="(420,510)"/>
+    <wire from="(150,610)" to="(150,650)"/>
+    <wire from="(410,390)" to="(420,390)"/>
+    <wire from="(160,600)" to="(160,650)"/>
+    <wire from="(530,510)" to="(530,570)"/>
+    <wire from="(180,700)" to="(190,700)"/>
+    <wire from="(520,600)" to="(520,650)"/>
+    <wire from="(170,210)" to="(170,650)"/>
+    <wire from="(460,160)" to="(460,220)"/>
+    <wire from="(460,250)" to="(460,370)"/>
+    <wire from="(340,720)" to="(400,720)"/>
+    <wire from="(440,90)" to="(440,220)"/>
+    <wire from="(520,650)" to="(570,650)"/>
+    <wire from="(420,210)" to="(420,220)"/>
+    <wire from="(320,150)" to="(320,160)"/>
+    <wire from="(120,210)" to="(170,210)"/>
+    <wire from="(170,110)" to="(280,110)"/>
+    <wire from="(420,490)" to="(420,510)"/>
+    <wire from="(420,390)" to="(420,410)"/>
+    <wire from="(430,440)" to="(430,460)"/>
+    <wire from="(280,320)" to="(390,320)"/>
+    <wire from="(110,430)" to="(410,430)"/>
+    <wire from="(570,120)" to="(570,650)"/>
+    <wire from="(20,320)" to="(250,320)"/>
+    <wire from="(430,130)" to="(430,220)"/>
+    <wire from="(110,430)" to="(110,650)"/>
+    <wire from="(310,190)" to="(310,280)"/>
+    <wire from="(480,120)" to="(570,120)"/>
+    <wire from="(480,120)" to="(480,220)"/>
+    <wire from="(430,440)" to="(460,440)"/>
+    <wire from="(280,110)" to="(310,110)"/>
+    <wire from="(280,190)" to="(310,190)"/>
+    <wire from="(530,510)" to="(690,510)"/>
+    <wire from="(170,70)" to="(450,70)"/>
+    <wire from="(130,610)" to="(150,610)"/>
+    <wire from="(140,600)" to="(160,600)"/>
+    <wire from="(320,160)" to="(460,160)"/>
+    <wire from="(420,410)" to="(420,460)"/>
+    <wire from="(410,340)" to="(410,390)"/>
+    <wire from="(180,670)" to="(190,670)"/>
+    <wire from="(510,520)" to="(510,570)"/>
+    <wire from="(430,520)" to="(510,520)"/>
+    <wire from="(120,150)" to="(320,150)"/>
+    <wire from="(120,150)" to="(120,210)"/>
+    <comp lib="6" loc="(423,264)" name="Text">
+      <a name="text" val="regToMux_opB"/>
+    </comp>
+    <comp lib="6" loc="(659,137)" name="Text">
+      <a name="text" val="15:13 AA"/>
+    </comp>
+    <comp lib="0" loc="(310,110)" name="Splitter">
+      <a name="facing" val="south"/>
+      <a name="incoming" val="4"/>
+      <a name="bit1" val="0"/>
+      <a name="bit2" val="0"/>
+      <a name="bit3" val="none"/>
+    </comp>
+    <comp lib="0" loc="(170,70)" name="Pin">
+      <a name="width" val="3"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="A"/>
+    </comp>
+    <comp lib="6" loc="(729,136)" name="Text">
+      <a name="text" val="A Address"/>
+    </comp>
+    <comp lib="0" loc="(670,370)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="4"/>
+      <a name="label" val="AddressOut"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="6" loc="(661,290)" name="Text">
+      <a name="text" val="0 WR"/>
+    </comp>
+    <comp loc="(430,490)" name="FU">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="6" loc="(356,370)" name="Text">
+      <a name="text" val="operandMuxToFU"/>
+    </comp>
+    <comp lib="0" loc="(340,720)" name="Pin">
+      <a name="output" val="true"/>
+      <a name="width" val="3"/>
+      <a name="label" val="PZN"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="6" loc="(363,671)" name="Text">
+      <a name="text" val="PZN_OUT"/>
+    </comp>
+    <comp lib="6" loc="(494,321)" name="Text">
+      <a name="text" val="regToMux_OpA"/>
+    </comp>
+    <comp lib="0" loc="(690,510)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="width" val="4"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="Data From Memory"/>
+    </comp>
+    <comp lib="1" loc="(280,320)" name="NOT Gate"/>
+    <comp loc="(460,250)" name="RF">
+      <a name="facing" val="south"/>
+    </comp>
+    <comp lib="2" loc="(520,600)" name="Multiplexer">
+      <a name="facing" val="south"/>
+      <a name="width" val="4"/>
+      <a name="enable" val="false"/>
+    </comp>
+    <comp lib="0" loc="(180,670)" name="Splitter">
+      <a name="facing" val="north"/>
+      <a name="fanout" val="4"/>
+      <a name="incoming" val="7"/>
+      <a name="bit4" val="3"/>
+      <a name="bit5" val="3"/>
+      <a name="bit6" val="3"/>
+    </comp>
+    <comp lib="0" loc="(390,210)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="CLK"/>
+    </comp>
+    <comp lib="6" loc="(465,541)" name="Text">
+      <a name="text" val="FUResultToMux"/>
+    </comp>
+    <comp lib="6" loc="(771,234)" name="Text">
+      <a name="text" val="Operation Code"/>
+    </comp>
+    <comp lib="6" loc="(657,261)" name="Text">
+      <a name="text" val="3:1 DA"/>
+    </comp>
+    <comp lib="0" loc="(180,700)" name="Pin">
+      <a name="width" val="7"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="FULL CONWORD"/>
+    </comp>
+    <comp lib="6" loc="(675,235)" name="Text">
+      <a name="text" val="7:4 OPCODE"/>
+    </comp>
+    <comp lib="0" loc="(170,110)" name="Pin">
+      <a name="width" val="4"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="C"/>
+    </comp>
+    <comp lib="6" loc="(563,64)" name="Text">
+      <a name="text" val="DATA PATH"/>
+    </comp>
+    <comp lib="6" loc="(756,212)" name="Text">
+      <a name="text" val="Data From Memory(?)"/>
+    </comp>
+    <comp lib="6" loc="(771,261)" name="Text">
+      <a name="text" val="Data Address (where to write)"/>
+    </comp>
+    <comp lib="6" loc="(329,559)" name="Text">
+      <a name="text" val="Data From Memory?"/>
+    </comp>
+    <comp lib="6" loc="(656,210)" name="Text">
+      <a name="text" val="8 DFM"/>
+    </comp>
+    <comp lib="6" loc="(659,185)" name="Text">
+      <a name="text" val="11:9 BA"/>
+    </comp>
+    <comp lib="6" loc="(727,184)" name="Text">
+      <a name="text" val="B Address"/>
+    </comp>
+    <comp lib="6" loc="(655,160)" name="Text">
+      <a name="text" val="12 BO"/>
+    </comp>
+    <comp lib="0" loc="(670,410)" name="Pin">
+      <a name="facing" val="west"/>
+      <a name="output" val="true"/>
+      <a name="width" val="4"/>
+      <a name="label" val="Data Out"/>
+      <a name="labelloc" val="east"/>
+    </comp>
+    <comp lib="0" loc="(170,20)" name="Pin">
+      <a name="width" val="3"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="D"/>
+    </comp>
+    <comp lib="6" loc="(541,666)" name="Text">
+      <a name="text" val="muxToRegisterFileDest"/>
+    </comp>
+    <comp lib="0" loc="(390,90)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="RESET"/>
+    </comp>
+    <comp lib="6" loc="(775,161)" name="Text">
+      <a name="text" val="B as Constant or From Memory"/>
+    </comp>
+    <comp lib="6" loc="(745,291)" name="Text">
+      <a name="text" val="Read Or write data"/>
+    </comp>
+    <comp lib="2" loc="(410,340)" name="Multiplexer">
+      <a name="facing" val="south"/>
+      <a name="width" val="4"/>
+      <a name="enable" val="false"/>
+    </comp>
+  </circuit>
+  <circuit name="PROC">
+    <a name="circuit" val="PROC"/>
+    <a name="clabel" val=""/>
+    <a name="clabelup" val="east"/>
+    <a name="clabelfont" val="SansSerif plain 12"/>
+    <appear>
+      <path d="M61,56 Q65,66 69,56" fill="none" stroke="#808080" stroke-width="2"/>
+      <rect fill="none" height="30" stroke="#000000" stroke-width="2" width="30" x="50" y="55"/>
+      <circ-port height="8" pin="250,90" width="8" x="46" y="56"/>
+      <circ-port height="8" pin="140,230" width="8" x="46" y="66"/>
+      <circ-port height="8" pin="140,300" width="8" x="46" y="76"/>
+      <circ-anchor facing="east" height="6" width="6" x="47" y="57"/>
+    </appear>
+    <wire from="(910,270)" to="(910,410)"/>
+    <wire from="(730,270)" to="(730,280)"/>
+    <wire from="(420,310)" to="(480,310)"/>
+    <wire from="(540,300)" to="(540,310)"/>
+    <wire from="(600,360)" to="(600,370)"/>
+    <wire from="(530,270)" to="(580,270)"/>
+    <wire from="(320,160)" to="(320,300)"/>
+    <wire from="(460,280)" to="(460,290)"/>
+    <wire from="(280,300)" to="(280,310)"/>
+    <wire from="(420,300)" to="(540,300)"/>
+    <wire from="(540,310)" to="(580,310)"/>
+    <wire from="(690,330)" to="(690,360)"/>
+    <wire from="(810,370)" to="(980,370)"/>
+    <wire from="(770,310)" to="(770,330)"/>
+    <wire from="(140,230)" to="(230,230)"/>
+    <wire from="(690,360)" to="(710,360)"/>
+    <wire from="(200,300)" to="(200,470)"/>
+    <wire from="(850,310)" to="(850,470)"/>
+    <wire from="(240,390)" to="(450,390)"/>
+    <wire from="(220,370)" to="(240,370)"/>
+    <wire from="(810,310)" to="(810,370)"/>
+    <wire from="(380,280)" to="(390,280)"/>
+    <wire from="(200,300)" to="(280,300)"/>
+    <wire from="(260,240)" to="(340,240)"/>
+    <wire from="(340,240)" to="(340,290)"/>
+    <wire from="(610,290)" to="(740,290)"/>
+    <wire from="(690,330)" to="(770,330)"/>
+    <wire from="(450,330)" to="(450,390)"/>
+    <wire from="(220,250)" to="(220,370)"/>
+    <wire from="(250,90)" to="(380,90)"/>
+    <wire from="(730,270)" to="(740,270)"/>
+    <wire from="(830,310)" to="(830,360)"/>
+    <wire from="(610,280)" to="(730,280)"/>
+    <wire from="(320,160)" to="(570,160)"/>
+    <wire from="(570,160)" to="(570,300)"/>
+    <wire from="(140,300)" to="(200,300)"/>
+    <wire from="(340,290)" to="(390,290)"/>
+    <wire from="(450,260)" to="(450,270)"/>
+    <wire from="(140,160)" to="(320,160)"/>
+    <wire from="(560,280)" to="(560,350)"/>
+    <wire from="(460,290)" to="(580,290)"/>
+    <wire from="(480,370)" to="(600,370)"/>
+    <wire from="(530,240)" to="(530,270)"/>
+    <wire from="(240,370)" to="(240,390)"/>
+    <wire from="(430,240)" to="(530,240)"/>
+    <wire from="(980,160)" to="(980,370)"/>
+    <wire from="(420,280)" to="(460,280)"/>
+    <wire from="(420,270)" to="(450,270)"/>
+    <wire from="(560,280)" to="(580,280)"/>
+    <wire from="(420,330)" to="(450,330)"/>
+    <wire from="(420,320)" to="(580,320)"/>
+    <wire from="(640,300)" to="(640,410)"/>
+    <wire from="(360,310)" to="(390,310)"/>
+    <wire from="(610,300)" to="(640,300)"/>
+    <wire from="(740,360)" to="(830,360)"/>
+    <wire from="(360,310)" to="(360,350)"/>
+    <wire from="(570,160)" to="(980,160)"/>
+    <wire from="(880,270)" to="(910,270)"/>
+    <wire from="(600,360)" to="(690,360)"/>
+    <wire from="(420,290)" to="(430,290)"/>
+    <wire from="(280,310)" to="(360,310)"/>
+    <wire from="(430,240)" to="(430,290)"/>
+    <wire from="(220,250)" to="(230,250)"/>
+    <wire from="(200,470)" to="(850,470)"/>
+    <wire from="(640,410)" to="(910,410)"/>
+    <wire from="(450,260)" to="(580,260)"/>
+    <wire from="(380,90)" to="(380,280)"/>
+    <wire from="(480,310)" to="(480,370)"/>
+    <wire from="(360,350)" to="(560,350)"/>
+    <wire from="(570,300)" to="(580,300)"/>
+    <wire from="(320,300)" to="(390,300)"/>
+    <comp loc="(420,270)" name="CU"/>
+    <comp loc="(610,280)" name="ALU"/>
+    <comp lib="1" loc="(260,240)" name="AND Gate">
+      <a name="size" val="30"/>
+      <a name="inputs" val="2"/>
+    </comp>
+    <comp lib="4" loc="(880,270)" name="RAM">
+      <a name="addrWidth" val="4"/>
+      <a name="dataWidth" val="4"/>
+      <a name="bus" val="separate"/>
+    </comp>
+    <comp lib="6" loc="(337,634)" name="Text">
+      <a name="text" val="RAM in included for data storage"/>
+    </comp>
+    <comp lib="1" loc="(740,360)" name="NOT Gate"/>
+    <comp lib="0" loc="(140,300)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="RESET"/>
+    </comp>
+    <comp lib="6" loc="(361,549)" name="Text">
+      <a name="text" val="Topview of the Processor"/>
+    </comp>
+    <comp lib="6" loc="(334,612)" name="Text">
+      <a name="text" val="DU is the datapath"/>
+    </comp>
+    <comp lib="0" loc="(140,160)" name="Clock">
+      <a name="label" val="CLK"/>
+    </comp>
+    <comp lib="6" loc="(349,660)" name="Text">
+      <a name="text" val="The CPU will only take an instruction if both START and READY are 1"/>
+    </comp>
+    <comp lib="0" loc="(250,90)" name="Pin">
+      <a name="width" val="14"/>
+      <a name="tristate" val="false"/>
+      <a name="label" val="INSTRUCTION"/>
+    </comp>
+    <comp lib="0" loc="(140,230)" name="Pin">
+      <a name="tristate" val="false"/>
+      <a name="label" val="START"/>
+    </comp>
+    <comp lib="6" loc="(286,376)" name="Text">
+      <a name="text" val="READY"/>
+    </comp>
+    <comp lib="6" loc="(343,587)" name="Text">
+      <a name="text" val="INSTRUCTION is fed into the CPU to be executed"/>
+    </comp>
+  </circuit>
+</project>


### PR DESCRIPTION
ALU and CU now support a shorter control word and the ALU register file is now accessed through the the instruction instead of hardwired into microinstructions; the B Registe (secondary source register) is now accessed by the const operand passed in by instructions. As a result, the size of microinstructions have decreased and their format when output to the ALU, branch controller and program counter have been appropriately modified.

ROMs have been added to the CU which should utilize onboard BRAM

A new logisim design is being uploaded as well.